### PR TITLE
Version-agnostic CircleCI container config references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 references:
-  container_config_node12: &container_config_node12
+  container_config_node: &container_config_node
       working_directory: ~/project/build
       docker:
         - image: circleci/node:12-browsers
@@ -45,7 +45,7 @@ references:
 version: 2
 jobs:
   build:
-    <<: *container_config_node12
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -59,7 +59,7 @@ jobs:
           paths:
             - build
   test:
-    <<: *container_config_node12
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run: 


### PR DESCRIPTION
Make CircleCI container config references version-agnostic, as the references have been known to get confused with the Docker image and get updated while the actual image remains on a different version.<br/><br/>This PR was created using a nori script 🍙<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._